### PR TITLE
fix: part fix for build on MacOS M1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ val codeMetrics = configurations.create("codeMetrics")
 dependencies {
     // For the "natives" configuration make it depend on the native files from LWJGL
     natives(platform("org.lwjgl:lwjgl-bom:$LwjglVersion"))
-    listOf("natives-linux", "natives-windows", "natives-macos").forEach {
+    listOf("natives-linux", "natives-windows", "natives-macos", "natives-macos-arm64").forEach {
         natives("org.lwjgl:lwjgl::$it")
         natives("org.lwjgl:lwjgl-assimp::$it")
         natives("org.lwjgl:lwjgl-glfw::$it")

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -158,7 +158,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.17.0"
+        artifact = "com.google.protobuf:protoc:3.18.0"
     }
     plugins {
     }


### PR DESCRIPTION
Partly fixes #5055 to add support for M1. Adds macOs-arm54 support for lwjgl and updated protobuf version to 3.18.0 (3.17.0 had no arm64 support)
